### PR TITLE
Fixed hard dependency on Extended Workbench

### DIFF
--- a/theoldone822/NetherrocksFusion/HandlerTick.java
+++ b/theoldone822/NetherrocksFusion/HandlerTick.java
@@ -29,7 +29,7 @@ public class HandlerTick implements ITickHandler
 			if(player != null && player.isUsingItem())
 			{
 				int itemID = player.getItemInUse().itemID;
-				if(itemID == Content.dragonbezoarBow.itemID || itemID == Content.extendeddragonbezoarBow.itemID)
+				if(itemID == Content.dragonbezoarBow.itemID || (EWAPI.getEWInstalled() && itemID == Content.extendeddragonbezoarBow.itemID))
 				{
 					NetherrocksFusion.proxy.onBowUse(player.getItemInUse(), player);
 						this.zoomAmount = (float) zoomAmount;


### PR DESCRIPTION
TickHandler REQUIRED that EW be installed, obviously this is not desirable.
